### PR TITLE
Adding the startUpdatingLocation function in case .AuthorizedAlways

### DIFF
--- a/OneShotLocationManager.swift
+++ b/OneShotLocationManager.swift
@@ -45,6 +45,8 @@ class OneShotLocationManager: NSObject, CLLocationManagerDelegate {
         switch status {
         case .AuthorizedWhenInUse:
             self.locationManager!.startUpdatingLocation()
+        case .AuthorizedAlways:
+            self.locationManager!.startUpdatingLocation()
         case .Denied:
             _didComplete(nil, error: NSError(domain: self.classForCoder.description(),
                 code: OneShotLocationManagerErrors.AuthorizationDenied.rawValue,


### PR DESCRIPTION
The manager was only working when using "NSLocationWhenInUseUsageDescription" because the case that triggers the location action for  "NSLocationAlwaysUsageDescription" didn't exist.
